### PR TITLE
Throw Exception when handle_function fails

### DIFF
--- a/WP_Mock/Handler.php
+++ b/WP_Mock/Handler.php
@@ -42,6 +42,7 @@ class Handler {
 
 			return call_user_func_array( $callback, $args );
 		}
+		throw new \Exception( 'Call to undefined function ' . $function_name . '()' );
 	}
 
 	/**


### PR DESCRIPTION
When a function is mocked using `Functions::create_function()`, two things are created:
1. The actual function is defined using `eval()`
2. The function handler is bound using `Handler:register_handler()`

When the test is complete and `Functions::flush()` is called, it removes the
handler, but nothing removes the function itself, which will continue to call
`Handler::handle_function()` in later tests, except that this will now be a
noop.

This can create problems when, for example, one test mocks a function to allow a
certain series of function calls, and then a later test also uses that series of
function calls, but does not mock the function. In this case, if the first test
is run before the second test, they will both pass, but if the second test is
run first (or in isolation), it will fail because it calls an undefined
function. Test Mocks should not cause tests to fail if run in different order.

While it may be impossible to replicate a call to an undefined function, we can
simulate it by throwing an Exception. This change causes
`Handler::handle_function()` to throw an Exception if it doesn't find a matching
handler.

Example:

``` php
<?php

class SomeClass {
  public function do_something( $times ) {
    $user = wp_get_current_user();
    //...
    return true;
  }
}

class MyTestClass extends PHPUnit_Framework_TestCase {
  public function setUp() {
    \WP_Mock::setUp();
    $this->something = new SomeClass();
  }

  public function tearDown() {
    \WP_Mock::tearDown();
  }

  public function test_do_something() {
    \WP_Mock::wpFunction( 'wp_get_current_user' );
    $this->assertTrue( $this->something->do_something( 1 ) );
  }

  public function test_do_something_again() {
    $this->assertTrue( $this->something->do_something( 2 ) ); // This should cause a fatal error, but it does not if run after the previous test
  }
}
```
